### PR TITLE
fixed the path as a cmake arg

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -104,11 +104,11 @@ Two libraries are required:
 ```bash
 git clone https://github.com/Syllo/nvtop.git
 mkdir -p nvtop/build && cd nvtop/build
-cmake ..
+cmake ../..
 
 # If it errors with "Could NOT find NVML (missing: NVML_INCLUDE_DIRS)"
 # try the following command instead, otherwise skip to the build with make.
-cmake .. -DNVML_RETRIEVE_HEADER_ONLINE=True
+cmake ../.. -DNVML_RETRIEVE_HEADER_ONLINE=True
 
 make
 make install # You may need sufficent permission for that (root)


### PR DESCRIPTION
If you run `cmake ..` in **nvtop/build** directory you get:

```
[...]
mkdir -p nvtop/build && cd nvtop/build
cmake ..

CMake Error: The source directory "nvtop/nvtop" does not appear to contain CMakeLists.txt.
Specify --help for usage, or press the help button on the CMake GUI.
```